### PR TITLE
fix building this module with current versions of Dist::Zilla and all

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -3,13 +3,22 @@ author           = Ævar Arnfjörð Bjarmason <avar@cpan.org>
 copyright_holder = Ævar Arnfjörð Bjarmason
 license          = Perl_5
 
-[@AVAR]
+[@Filter]
+-bundle = @AVAR
+-remove = PkgVersion
+option = for_basic
 dist = re-engine-PCRE
 use_MakeMaker    = 0
 use_CompileTests = 0
 bugtracker = rt
 
+[PkgVersion]
+use_begin = 1
+
 [=inc::PCREMakeMaker / PCREMakeMaker]
 
-[Prereq]
+[Prereqs]
 perl = 5.010
+
+[Prereqs / BuildRequires]
+Dist::Zilla::Plugin::MakeMaker::Awesome = 0.33


### PR DESCRIPTION
I've been assigned this module as part of the CPAN-PR challenge. I quickly noticed that the repo wouldn't build with current Dist::Zilla. This is mainly due to the fact that @rjbs changed PkgVersion plugin: now it doesn't wrap setting VERSION in a BEGIN block, making the XSLoader call at begin time fail.

I've fixed it in a Dist::Zilla PR: https://github.com/rjbs/Dist-Zilla/pull/428 and used it in this PR (the trick is the use_begin option). Obviously you'll want to wait for the Dist::Zilla PR to be merged before merging this one.

Thank you !
