### PR TITLE
use Prereqs for new Dist::Zilla versions

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -11,5 +11,5 @@ bugtracker = rt
 
 [=inc::PCREMakeMaker / PCREMakeMaker]
 
-[Prereq]
+[Prereqs]
 perl = 5.010


### PR DESCRIPTION
I wasn't able to run dzil  test, and it gave me an error saying use Prereqs for version >= 5
