### PR TITLE
Updates for newer perls

### DIFF
--- a/PCRE.h
+++ b/PCRE.h
@@ -2,17 +2,34 @@
 
 START_EXTERN_C
 EXTERN_C const regexp_engine pcre_engine;
-EXTERN_C REGEXP * PCRE_comp(pTHX_ const SV const *, const U32);
+#if PERL_VERSION < 12
+EXTERN_C REGEXP * PCRE_comp(pTHX_ const SV * const, const U32);
+#else
+EXTERN_C REGEXP * PCRE_comp(pTHX_ SV * const, U32);
+#endif
+#if PERL_VERSION < 20
 EXTERN_C I32      PCRE_exec(pTHX_ REGEXP * const, char *, char *,
                               char *, I32, SV *, void *, U32);
-EXTERN_C char *   PCRE_intuit(pTHX_ REGEXP * const, SV *, char *,
-                                char *, U32, re_scream_pos_data *);
+EXTERN_C char *   PCRE_intuit(pTHX_ REGEXP * const, SV *,
+                               char *, char *, const U32, re_scream_pos_data *);
+#else
+EXTERN_C I32      PCRE_exec(pTHX_ REGEXP * const, char *, char *,
+                              char *, SSize_t, SV *, void *, U32);
+EXTERN_C char *   PCRE_intuit(pTHX_ REGEXP * const, SV *, const char *,
+                               char *, char *, U32, re_scream_pos_data *);
+#endif
 EXTERN_C SV *     PCRE_checkstr(pTHX_ REGEXP * const);
 EXTERN_C void     PCRE_free(pTHX_ REGEXP * const);
 /* No numbered/named buff callbacks */
 EXTERN_C SV *     PCRE_package(pTHX_ REGEXP * const);
 #ifdef USE_ITHREADS
 EXTERN_C void *   PCRE_dupe(pTHX_ REGEXP * const, CLONE_PARAMS *);
+#endif
+#if PERL_VERSION >= 18
+EXTERN_C REGEXP*  PCRE_op_comp(pTHX_ SV ** const patternp, int pat_count,
+                                OP *expr, const struct regexp_engine* eng,
+                                REGEXP *old_re,
+                                bool *is_bare_re, U32 orig_rx_flags, U32 pm_flags);
 #endif
 END_EXTERN_C
 
@@ -32,5 +49,8 @@ const regexp_engine pcre_engine = {
     PCRE_package,
 #if defined(USE_ITHREADS)        
     PCRE_dupe,
+#endif
+#if PERL_VERSION >= 18
+    PCRE_op_comp,
 #endif
 };

--- a/t/s.t
+++ b/t/s.t
@@ -2,7 +2,7 @@ use strict;
 use Test::More tests => 10;
 use re::engine::PCRE;
 
-my $_;
+#my $_;
 
 $_ = "ab";
 s/a//;


### PR DESCRIPTION
compat updates for the various regex hooks.

added op_comp to get lexicals in /e, but this is a hack. 
dave mitchell should fix this. haven't studied his new hack yet.

I've started with a pcre2 version and jit support at https://github.com/rurban/re-engine-PCRE2