### PR TITLE
Fix prototypes of struct regexp_engine members

### DIFF
--- a/PCRE.h
+++ b/PCRE.h
@@ -2,11 +2,15 @@
 
 START_EXTERN_C
 EXTERN_C const regexp_engine pcre_engine;
-EXTERN_C REGEXP * PCRE_comp(pTHX_ const SV const *, const U32);
+EXTERN_C REGEXP * PCRE_comp(pTHX_ SV * const, U32);
 EXTERN_C I32      PCRE_exec(pTHX_ REGEXP * const, char *, char *,
-                              char *, I32, SV *, void *, U32);
-EXTERN_C char *   PCRE_intuit(pTHX_ REGEXP * const, SV *, char *,
-                                char *, U32, re_scream_pos_data *);
+                              char *, SSize_t, SV *, void *, U32);
+EXTERN_C char *   PCRE_intuit(pTHX_ REGEXP * const, SV *,
+#if PERL_VERSION >= 20
+                                const char * const,
+#endif
+                                char *, char *, const U32,
+                                re_scream_pos_data *);
 EXTERN_C SV *     PCRE_checkstr(pTHX_ REGEXP * const);
 EXTERN_C void     PCRE_free(pTHX_ REGEXP * const);
 /* No numbered/named buff callbacks */

--- a/PCRE.xs
+++ b/PCRE.xs
@@ -13,7 +13,7 @@
 #endif
 
 REGEXP *
-PCRE_comp(pTHX_ const SV * const pattern, const U32 flags)
+PCRE_comp(pTHX_ SV * const pattern, U32 flags)
 {
     REGEXP *rx;
     regexp *re;
@@ -178,7 +178,7 @@ PCRE_comp(pTHX_ const SV * const pattern, const U32 flags)
 
 I32
 PCRE_exec(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
-          char *strbeg, I32 minend, SV * sv,
+          char *strbeg, SSize_t minend, SV * sv,
           void *data, U32 flags)
 {
     I32 rc;
@@ -235,11 +235,18 @@ PCRE_exec(pTHX_ REGEXP * const rx, char *stringarg, char *strend,
 }
 
 char *
-PCRE_intuit(pTHX_ REGEXP * const rx, SV * sv, char *strpos,
-             char *strend, U32 flags, re_scream_pos_data *data)
+PCRE_intuit(pTHX_ REGEXP * const rx, SV * sv,
+#if PERL_VERSION >= 20
+             const char * const strbeg,
+#endif
+             char *strpos, char *strend, const U32 flags,
+             re_scream_pos_data *data)
 {
 	PERL_UNUSED_ARG(rx);
 	PERL_UNUSED_ARG(sv);
+#if PERL_VERSION >= 20
+	PERL_UNUSED_ARG(strbeg);
+#endif
 	PERL_UNUSED_ARG(strpos);
 	PERL_UNUSED_ARG(strend);
 	PERL_UNUSED_ARG(flags);


### PR DESCRIPTION
GCC 14 became picky regarding const correctness in pointers:

    In file included from PCRE.xs:7:
    PCRE.h:5:44: warning: duplicate ‘const’ declaration specifier [-Wduplicate-decl-specifier]
	5 | EXTERN_C REGEXP * PCRE_comp(pTHX_ const SV const *, const U32);
	  |                                            ^~~~~
    PCRE.h:22:5: error: initialization of ‘REGEXP * (*)(PerlInterpreter *, SV * const,  U32)’ {aka ‘struct p5rx * (*)(struct interpreter *, struct sv * const,  unsigned int)’} from incompatible pointer type ‘REGEXP * (*)(PerlInterpreter *, const SV *, const U32)’ {aka ‘struct p5rx * (*)(struct interpreter *, const struct sv *, const unsigned int)’} [-Wincompatible-pointer-types]
       22 |     PCRE_comp,
	  |     ^~~~~~~~~
    PCRE.h:22:5: note: (near initialization for ‘pcre_engine.comp’)
    PCRE.h:23:5: error: initialization of ‘I32 (*)(PerlInterpreter *, REGEXP * const,  char *, char *, char *, ssize_t,  SV *, void *, U32)’ {aka ‘int (*)(struct interpreter *, struct p5rx * const,  char *, char *, char *, long int,  struct sv *, void *, unsigned int)’} from incompatible pointer type ‘I32 (*)(PerlInterpreter *, REGEXP * const,  char *, char *, char *, I32,  SV *, void *, U32)’ {aka ‘int (*)(struct interpreter *, struct p5rx * const,  char *, char *, char *, int,  struct sv *, void *, unsigned int ’} [-Wincompatible-pointer-types]
       23 |     PCRE_exec,
	  |     ^~~~~~~~~
    PCRE.h:23:5: note: (near initialization for ‘pcre_engine.exec’)
    PCRE.h:24:5: error: initialization of ‘char * (*)(PerlInterpreter *, REGEXP * const,  SV *, const char * const,  char *, char *, const U32,  re_scream_pos_data *)’ {aka ‘char * (*)(struct interpreter *, struct p5rx * const,  struct sv *, const char * const,  char *, char *, const unsigned int,  struct re_scream_pos_data_s *)’} from incompatible pointer type ‘char * (*)(PerlInterpreter *, REGEXP * const,  SV *, char *, char *, U32,  re_scream_pos_data *)’ {aka ‘char * (*)(struct interpreter *, struct p5rx * const,  struct sv *, char *, char *, unsigned int,  struct re_scream_pos_data_s *)’} [-Wincompatible-pointer-types]
       24 |     PCRE_intuit,
	  |     ^~~~~~~~~~~
    PCRE.h:24:5: note: (near initialization for ‘pcre_engine.intuit’)

The reason is that the prototypes of PCRE_comp(), PCRE_exec(), and PCRE_intuit() callbacks do not match wgat Perl's regexp.h expect. Also PCRE_intuit() changed a number of arguments in v5.19.1. Fortunatelly re-engine-PCRE did not use them.

This patch changes the prototypes to match what Perl headers prescribe.